### PR TITLE
Negative Abbuchungsbetraege zulassen 

### DIFF
--- a/src/de/jost_net/OBanToo/SEPA/Basislastschrift/Basislastschrift.java
+++ b/src/de/jost_net/OBanToo/SEPA/Basislastschrift/Basislastschrift.java
@@ -187,6 +187,8 @@ public class Basislastschrift
       Zahler z = zahlermap.get(zahler.getMandatid());
       if (z == null)
       {
+    	if(zahler.getBetrag().compareTo(new BigDecimal("0.00")) == -1)
+    		throw new SEPAException("Ungültiger Betrag: " + zahler.getBetrag());
         zahlermap.put(zahler.getMandatid(), zahler);
       }
       else
@@ -196,6 +198,8 @@ public class Basislastschrift
     }
     else
     {
+      if(zahler.getBetrag().compareTo(new BigDecimal("0")) == -1)
+    	  throw new SEPAException("Ungültiger Betrag: " + zahler.getBetrag());
       zahlerarray.add(zahler);
     }
   }

--- a/src/de/jost_net/OBanToo/SEPA/Basislastschrift/Zahler.java
+++ b/src/de/jost_net/OBanToo/SEPA/Basislastschrift/Zahler.java
@@ -227,7 +227,8 @@ public class Zahler
 
   public void checkBetrag(BigDecimal betrag) throws SEPAException
   {
-    if (betrag == null || betrag.compareTo(nu) == -1
+    if (betrag == null 
+    	//|| (betrag.compareTo(nu) == -1) //Negative erlauben
         || betrag.compareTo(nu) == 0)
     {
       throw new SEPAException("Ungültiger Betrag: " + betrag);
@@ -308,6 +309,8 @@ public class Zahler
       verwendungszweck += " " + this.getBetrag();
     }
     betrag = betrag.add(zahler.getBetrag());
+    if(betrag.compareTo(new BigDecimal("0.00")) == -1)
+    	throw new SEPAException("Ungültiger Betrag: " + betrag);
     if (verwendungszweck.length() == 140 && verwendungszweck.endsWith("..."))
     {
       return;


### PR DESCRIPTION
(solange sie nicht zu insgesamtnagativen Abbuchungsbeträgen führen)
In JVerein würde ich gerne negative Zusatzbeiträge zulassen, so kann man auch Erstattungen verbuchen. Bei kompakter Abbuchung geht das, solange die Gesamtsumme positiv ist.
Dafür ist diese Änderung bei Obantoo nötig