### PR TITLE
Fehler behoben: Betrag bei mehreren Abbuchungen bei jeder dazuschreiben

### DIFF
--- a/src/de/jost_net/OBanToo/SEPA/Basislastschrift/Zahler.java
+++ b/src/de/jost_net/OBanToo/SEPA/Basislastschrift/Zahler.java
@@ -299,13 +299,14 @@ public class Zahler
       verwendungszweckorig = "";
       verwendungszwecke = 1;
     }
-    else
-    {
-      verwendungszwecke++;
-    }
+    
     if (verwendungszwecke == 1)
     {
       verwendungszweck += " " + this.getBetrag();
+    }
+    if (verwendungszweck != null)
+    {
+      verwendungszwecke++;
     }
     betrag = betrag.add(zahler.getBetrag());
     if (verwendungszweck.length() == 140 && verwendungszweck.endsWith("..."))


### PR DESCRIPTION
Bisher werden beim ersten Abbuchungsbetrag die Beträge im Verwendungszweck nicht angegeben.